### PR TITLE
add: phony e variáveis Make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,15 @@
-all:	 JR.o concorrentes.o 
-	@g++  JR.o  concorrentes.o -o concorrentes -lpthread -g
+.PHONY: all
+all: JR.o concorrentes.o 
+	@$(CXX) $^ -o concorrentes -lpthread -g
 
-JR.o:
-	@g++ -Wall -c JR.c -lpthread -g
+%.o:
+	@$(CXX) -c $(@:.o=.c) -Wall -g
 
-concorrentes.o:
-	@g++  -Wall -c concorrentes.c -g
-
+.PHONY: clean
 clean:
 	@rm *.o concorrentes
 	@rm -r out/*/*/*
+	
+.PHONY: run
 run:
 	@./concorrentes


### PR DESCRIPTION
.PHONY especifica que a regra não é para gerar um arquivo, caso contrário (por exemplo) se existir um arquivo chamado "clean" o make não vai querer rodar "make clean", pois o alvo já existe
$(CXX) compilador C++ default
$^ todas as dependências da regra
$@ alvo da regra
$(VAR:x=y) substitui x por y no fim do valor de VAR